### PR TITLE
更正了服务器拒绝服务的时间间隔，从 6 秒改为 60 秒。

### DIFF
--- a/sources/sms/index.md
+++ b/sources/sms/index.md
@@ -134,7 +134,7 @@ signature = hashlib.md5(sign_str).hexdigest()
 
 **timestamp 时间戳 ( 提升逼格 )**
 
-用户可以在每个 API 请求中加入 timestamp 参数, SendCloud 会检查 timestamp 和 服务器当前时间, 如果两者相差大于6秒, 则请求会被拒绝.
+用户可以在每个 API 请求中加入 timestamp 参数, SendCloud 会检查 timestamp 和 服务器当前时间, 如果两者相差大于60秒, 则请求会被拒绝.
 
 用户需要通过调用 API 来获取 SendCloud 服务器的时间戳, 而不是自己的本地时间.
 


### PR DESCRIPTION
为了提升逼格的时间戳并没有什么卵用。。。虽然是写着超过 6 秒服务器就会拒绝服务，实际上经过测试超过 10 秒服务器还是可以接受。后来时间戳直接设为 1，服务器终于提示拒绝服务，说时间戳超过了服务器当前时间 60 秒，所以要么是文档错了，要么是实现错了。。。
